### PR TITLE
Fix #359

### DIFF
--- a/packages/platforms/react/src/types-react.d.ts
+++ b/packages/platforms/react/src/types-react.d.ts
@@ -35,7 +35,7 @@ export interface RelationGraphJsxProps {
   onNodeDragging?: (node:RGNode, newX:number, newY:number, e:RGUserEvent) => RGPosition | undefined
   onCanvasDragEnd?: (e:RGUserEvent) => void
   onContextmenu?: (e:RGUserEvent, objectType:RGEventTargetType, object:RGNode|RGLink|undefined) => void
-  onFullscreen?: (newValue:boolean) => void
+  onFullscreen?: (newValue:boolean, defaultFullscreen: () => Promise<void>) => void
   onCanvasClick?: (e:RGUserEvent) => void
   onCanvasSelectionEnd?: (selectionView:RGSelectionView, e:RGUserEvent) => void
   onZoomEnd?: () => void

--- a/packages/platforms/vue3/src/relation-graph/src/core4vue3/index.vue
+++ b/packages/platforms/vue3/src/relation-graph/src/core4vue3/index.vue
@@ -40,7 +40,7 @@ interface RelationGraphProps {
   onNodeDragging?: (node:RGNode, newX:number, newY:number, e:RGUserEvent) => RGPosition | undefined
   onCanvasDragEnd?: (e:RGUserEvent) => void
   onContextmenu?: (e:RGUserEvent, objectType:RGEventTargetType, object:RGNode|RGLink|undefined) => void
-  onFullscreen?: (newValue:boolean) => void
+  onFullscreen?: (newValue:boolean, defaultFullscreen: () => Promise<void>) => void
   onCanvasClick?: (e:RGUserEvent) => void
   onCanvasSelectionEnd?: (selectionView:RGSelectionView, e:RGUserEvent) => void
   onZoomEnd?: () => void

--- a/packages/relation-graph-models/models/RelationGraphWith7Event.ts
+++ b/packages/relation-graph-models/models/RelationGraphWith7Event.ts
@@ -483,7 +483,7 @@ export class RelationGraphWith7Event extends RelationGraphWith6Effect {
         await screenfull.toggle(this.$dom);
       }
     }
-    this.emitEvent('fullscreen', { fullscreen: this.options.fullscreen });
+    this.emitEvent('onFullscreen', { fullscreen: this.options.fullscreen });
   }
   async focusNodeById(nodeId:string) {
     let node;

--- a/packages/relation-graph-models/models/RelationGraphWith7Event.ts
+++ b/packages/relation-graph-models/models/RelationGraphWith7Event.ts
@@ -466,8 +466,11 @@ export class RelationGraphWith7Event extends RelationGraphWith6Effect {
       this.listeners.onContextmenu(e, objectType, object);
     }
   }
-  async fullscreen(newValue?:boolean) {
+  async fullscreen(newValue?: boolean) {
     if (screenfull.element && screenfull.element !== this.$dom) {
+      return;
+    }
+    if (newValue === this.options.fullscreen) {
       return;
     }
     let isToogle = false;
@@ -475,15 +478,17 @@ export class RelationGraphWith7Event extends RelationGraphWith6Effect {
       newValue = !this.options.fullscreen;
       isToogle = true;
     }
+    devLog("screenfull", newValue);
     this.options.fullscreen = newValue;
+    const defaultEffect = async () => {
+      if (isToogle) await screenfull.toggle(this.$dom);
+    };
     if (this.listeners.onFullscreen) {
-      this.listeners.onFullscreen(this.options.fullscreen);
+      this.listeners.onFullscreen(this.options.fullscreen, defaultEffect);
     } else {
-      if (isToogle) {
-        await screenfull.toggle(this.$dom);
-      }
+      await defaultEffect();
     }
-    this.emitEvent('onFullscreen', { fullscreen: this.options.fullscreen });
+    // this.emitEvent('onFullscreen', { fullscreen: this.options.fullscreen });
   }
   async focusNodeById(nodeId:string) {
     let node;

--- a/packages/relation-graph-models/types.ts
+++ b/packages/relation-graph-models/types.ts
@@ -345,7 +345,7 @@ export interface RGListeners {
   onNodeDragging?: (node:RGNode, newX:number, newY:number, e:RGUserEvent) => RGPosition | undefined
   onCanvasDragEnd?: (e:RGUserEvent) => void
   onContextmenu?: (e:RGUserEvent, objectType:RGEventTargetType, object:RGNode|RGLink|undefined) => void
-  onFullscreen?: (newValue:boolean) => void
+  onFullscreen?: (newValue:boolean, defaultFullscreen: () => Promise<void>) => void
   onCanvasClick?: (e:RGUserEvent) => void
   onCanvasSelectionEnd?: (selectionView:RGSelectionView, e:RGUserEvent) => void
   // 不要在这个时间中调用任何触发setZoom的动作

--- a/types/vue3.d.ts
+++ b/types/vue3.d.ts
@@ -73,7 +73,7 @@ export type RelationGraphProps = {
   onNodeDragging?: (node:RGNode, newX:number, newY:number, e:RGUserEvent) => RGPosition | undefined
   onCanvasDragEnd?: (e: RGUserEvent) => void;
   onContextmenu?: (e: RGUserEvent, objectType: RGEventTargetType, object: RGNode | RGLink | undefined) => void;
-  onFullscreen?: (newValue:boolean) => void
+  onFullscreen?: (newValue:boolean, defaultFullscreen: () => Promise<void>) => void;
   onCanvasClick?: (e: RGUserEvent) => void;
   onCanvasSelectionEnd?: (selectionView: RGSelectionView, e: RGUserEvent) => void;
   onZoomEnd?: () => void


### PR DESCRIPTION
沒帶電腦 用ipad瀏覽器網頁手搓的多個commit。

修復前 `onFullscreen` 綁定的函式無法觸發

修復后的用法 第二個參數係默認行爲

```tsx
import RelationGraph from "relation-graph-react"
const graphRef = useRef<RelationGraphComponent>()

<RelationGraph
    ref={graphRef}
    onFullscreen={async (v, fullscreen) => {
        await fullscreen()
        const graphInstance = graphRef.current?.getInstance()
        if (graphInstance) {
            await graphInstance.refresh()
        }
    }}
/>
```