### PR TITLE
解决react 18.0 节点编辑状态 的拖拽卡顿 bug

### DIFF
--- a/packages/relation-graph-models/models/RelationGraphWith7Event.ts
+++ b/packages/relation-graph-models/models/RelationGraphWith7Event.ts
@@ -130,7 +130,6 @@ export class RelationGraphWith7Event extends RelationGraphWith6Effect {
       }
       this.emitEvent('node-dragging', {node, x, y});
       this.updateElementLines();
-      this._dataUpdated();
     });
   }
   onNodeDraged(node:RGNode, x_buff:number, y_buff:number, e:RGUserEvent) {


### PR DESCRIPTION
在react 18.0 之后的版本中 设置setEditingNodes([node]) 之后 拖拽这个节点 会有明细的卡顿
初步判断 
this.emitEvent('node-dragging', {node, x, y}); 这个方法里面会调用_dataUpdated 
这里也调用了_dataUpdated
去掉这里这个就能解决卡顿问题
或者在node-dragging方法里面去掉